### PR TITLE
Fixes todays query

### DIFF
--- a/src/db/__tests__/intergration_user_match.test.ts
+++ b/src/db/__tests__/intergration_user_match.test.ts
@@ -79,7 +79,7 @@ describe('User-UserMatch-Match tests:', () => {
   });
 
   it('should be able to get users to match today, who are active and not skipping', () => {
-    const usersPrevMatch = DB.User.findUsersPrevMatchesToday();
+    const usersPrevMatch = DB.User.findUsersPrevMatchesToday(1);
     const todaysUsers = usersPrevMatch.map(user => user.email);
 
     usersPrevMatch.forEach(user => {

--- a/src/db/models/user_model.ts
+++ b/src/db/models/user_model.ts
@@ -165,7 +165,7 @@ export class UserModel extends Model<UserRecord> {
     SELECT U2.*, prevMatches.num_matches from User U2
       LEFT JOIN prevMatches
       ON prevMatches.user_id = U2.id
-      WHERE U2.coffee_days LIKE '%1%' and U2.is_active <> 0 and U2.skip_next_match <> 1;
+      WHERE U2.coffee_days LIKE '%${matchDayInt}%' and U2.is_active <> 0 and U2.skip_next_match <> 1;
     `);
 
     // NOTE: num_matches will be null if there are no prevmatches --> ensures num_matches


### PR DESCRIPTION
The query for selecting todays matches still had the coffee_day hard coded instead of a placeholder.

This bug resulted in selecting users who wanted to be matched on monday