### PR TITLE
Is active middleware

### DIFF
--- a/src/middleware/action-creater.ts
+++ b/src/middleware/action-creater.ts
@@ -5,9 +5,7 @@
 import * as types from '../types';
 
 export function actionCreater(req: types.IZulipRequest, res, next) {
-  const { isRegistered, email } = req.local.user;
-  // TEMP:
-  const isActive = true;
+  const { isRegistered, isActive } = req.local.user;
   let actionType: types.Action | null = null;
 
   // Case: Handle if user is not registered or is not active
@@ -23,9 +21,22 @@ export function actionCreater(req: types.IZulipRequest, res, next) {
         rawInput: {}
       }
     };
-    next();
+
+    return next();
   } else if (!isActive) {
-    // TODO: implement this!
+    const wantsToActivate = req.body.data.match(/activate/gi);
+    actionType = wantsToActivate
+      ? types.Action.__ACTIVATE
+      : types.Action.__PROMPT_ACTIVATE;
+
+    req.local.action = {
+      actionType,
+      actionArgs: {
+        rawInput: {}
+      }
+    };
+
+    return next();
   }
 
   // Special Case: where users enters a command that does not follow

--- a/src/middleware/action-handler.ts
+++ b/src/middleware/action-handler.ts
@@ -10,6 +10,7 @@ import { getProjectIssues } from '../utils/getIssues';
 // NOTE: all errors thrown in action functions will be handled
 // by the dispatcher(), which will send a generic error msg:
 export const ActionHandlerMap: types.ActionHandlerMap = {
+  // isRegistered CMDS
   __PROMPT_SIGNUP() {
     return new Promise(resolve => {
       resolve({
@@ -27,6 +28,20 @@ export const ActionHandlerMap: types.ActionHandlerMap = {
       resolve({ msgTemplate: types.msgTemplate.SIGNED_UP });
     });
   },
+  // isActive CMDS
+  __ACTIVATE(ctx) {
+    return new Promise(resolve => {
+      ctx.db.User.update({ is_active: 1 }, { email: ctx.userEmail });
+
+      resolve({ msgTemplate: types.msgTemplate.ACTIVATE });
+    });
+  },
+  __PROMPT_ACTIVATE() {
+    return new Promise(resolve => {
+      resolve({ msgTemplate: types.msgTemplate.PROMPT_ACTIVATE });
+    });
+  },
+
   ////////////////
   // SHOW
   ////////////////
@@ -245,6 +260,32 @@ export const ActionHandlerMap: types.ActionHandlerMap = {
       });
     });
   },
+
+  UPDATE__ACTIVE(ctx, actionArgs) {
+    return new Promise(resolve => {
+      // VALIDATE:
+      const falseArgs = ['0', 'FALSE', 'NO', 'OFF'];
+      const validArgs = new Set([...falseArgs]);
+
+      if (actionArgs.length !== 1) {
+        throw new Error(
+          `Update skip takes one boolean argument. The following are valid arguments: *${falseArgs.join(
+            ', '
+          )}*`
+        );
+      } else if (!validArgs.has(actionArgs[0])) {
+        throw new Error(`${actionArgs[0]} is not a valid argument`);
+      }
+
+      // UPDATE QUERY:
+      ctx.db.User.update({ is_active: 0 }, { email: ctx.userEmail });
+
+      resolve({
+        msgTemplate: types.msgTemplate.DEACTIVATE
+      });
+    });
+  },
+
   ////////////////
   // HELP
   ////////////////

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface IZulipRequest extends Express.Request {
     user: {
       email: string;
       isRegistered: boolean;
+      isActive: boolean;
       data?: UserRecord;
     };
     cmd: IParsedCmd;
@@ -72,6 +73,10 @@ export interface IParsedCmd {
 export enum Action {
   '__PROMPT_SIGNUP' = '__PROMPT_SIGNUP',
   '__REGISTER' = '__REGISTER',
+
+  '__ACTIVATE' = '__ACTIVATE',
+  '__PROMPT_ACTIVATE' = '__PROMPT_ACTIVATE',
+
   // === SHOW actions ====
   'SHOW__DAYS' = 'SHOW__DAYS',
   'SHOW__PREVIOUS' = 'SHOW__PREVIOUS',
@@ -84,7 +89,7 @@ export enum Action {
   'UPDATE__SKIP' = 'UPDATE__SKIP',
   'UPDATE__SKIPPING' = 'UPDATE__SKIPPING',
   'UPDATE__WARNINGS' = 'UPDATE__WARNINGS',
-  // 'UPDATE__ACTIVE' = 'UPDATE__ACTIVE',
+  'UPDATE__ACTIVE' = 'UPDATE__ACTIVE',
 
   'HELP' = 'HELP',
   'HELP__SHOW' = 'HELP__SHOW',
@@ -137,6 +142,10 @@ export enum msgTemplate {
   'BLANK' = 'BLANK',
   'PROMPT_SIGNUP' = 'PROMPT_SIGNUP',
   'SIGNED_UP' = 'SIGNED_UP',
+
+  'PROMPT_ACTIVATE' = 'PROMPT_ACTIVATE',
+  'ACTIVATE' = 'ACTIVATE',
+  'DEACTIVATE' = 'DEACTIVATE',
 
   // CLI Update-related cmds
   'UPDATED_GENERAL' = 'UPDATED_GENERAL',
@@ -193,7 +202,8 @@ export enum Errors {
   'COULD_NOT_VALIDATE_ACTION' = 'COULD_NOT_VALIDATE_ACTION',
   'NO_VALID_ACTION' = 'NO_VALID_ACTION',
   'DISPATCH_ACTION_DOES_NOT_EXIST' = 'DISPATCH_ACTION_DOES_NOT_EXIST',
-  'NOPE' = 'NOPE' // TODO: temp
+  'NOPE' = 'NOPE', // TODO: temp
+  'GENERAL' = 'GENERAL'
 }
 
 ////////////////////////////

--- a/src/zulip-messenger/msg-sender.ts
+++ b/src/zulip-messenger/msg-sender.ts
@@ -80,6 +80,19 @@ export function createMessageContent(
       or just type: **HELP**`
     },
     ////////////////////////
+    // Activate related messages
+    ////////////////////////
+    PROMPT_ACTIVATE: {
+      template: `Hi, looks like you are not currently an active user of chat bot and will not be paired with anyone for any chats. You can type: *ACTIVATE* to rejoin.`
+    },
+    ACTIVATE: {
+      template: `Welcome back to Chat Bot! 🎉`
+    },
+    DEACTIVATE: {
+      template: `Your account has been deactivated 😭\n We're sad to see you go, but we hope you've had some wonderful chats at RC!`
+    },
+
+    ////////////////////////
     // Messages related to SHOW actions
     ////////////////////////
 


### PR DESCRIPTION
This PR fixes #19 and also handles the logic for an inactive user trying to rejoin coffee chat bot

## Reasoning
If a user is no longer *active*, their account is essentially frozen and should not be able to really interact with the bot. Therefore, I needed to add a check within the isRegistered middleware for checking if the user is active or not and then also creating the appropriate action to take in the `action-creater.ts`

I wanted to avoid the situation where a user could essentially inactivate their account by setting their days to be none OR by setting is_active to false. That way it will be easier for an admin/maintainer to see how many users are currently on coffee chat bot.