### PR TITLE
Fix user test

### DIFF
--- a/src/db/models/user_model.ts
+++ b/src/db/models/user_model.ts
@@ -279,7 +279,7 @@ export class UserModel extends Model<UserRecord> {
         if (a > b) {
           return 1;
         }
-        if (b < a) {
+        if (a < b) {
           return -1;
         }
         return 0;


### PR DESCRIPTION
@capnfabs and I noticed this while doing #96 . On my machine (node v13)
`it('should be able to update the users weekdays')`  test was failing:
it was returning '21' and expecting '12' as the updated days.
We noticed that the sort implementation in updateDays wasn't working to sort the days properly by having `a<b` twice (compare line 279 to 282) . Not sure if this is important elsewhere in the app but we fixed it.