### PR TITLE
send matches the previous day

### DIFF
--- a/src/crons/hourly.ts
+++ b/src/crons/hourly.ts
@@ -26,9 +26,8 @@ function hourly() {
   console.log(`>> Cron timecheck:`, now.toString(), { hour });
   console.log('>> Node env:', process.env.NODE_ENV);
 
-  // Run at 8pm EST
-  if (hour === 8) {
-    // makes matches and notifies users
+  if (hour === 22) {
+    // Run at 10pm EST and send matches for the next day
     matchify();
   } else if (hour === 15) {
     handlePossibleOffBoarding();
@@ -36,7 +35,7 @@ function hourly() {
   } else if (hour === 19) {
     // send warning notifications
     sendNextDayMatchWarning();
-  } else if (hour === 23) {
+  } else if (hour === 21) {
     UpdateZoomUrlForUsers();
   }
 }

--- a/src/crons/matchify/index.ts
+++ b/src/crons/matchify/index.ts
@@ -35,6 +35,9 @@ export async function matchify() {
   const db = initDB();
   const weekday = moment()
     .tz('America/New_York')
+     // Add one day because we run matchify at 10pm the previous day.
+     // So if we're running on Tuesday, we want to make matches for Wednesday.
+    .add(1, 'day')
     .day();
 
   const { todaysMatches, unmatchedUser } = makeMatches(db, weekday);

--- a/src/crons/matchify/notify-match-pair.ts
+++ b/src/crons/matchify/notify-match-pair.ts
@@ -27,9 +27,9 @@ export function notifyMatchPair(match: matchPair) {
 
   // TODO: add links to the names of the users here
   const msgContent =
-    `☀️ Good morning ${nameLinks.join(
+    `Hello ${nameLinks.join(
       ' and '
-    )}! \nThe two of you have been paired for a chat today. Hope you get a chance to chat over coffee or tea or anything that you fancy -- enjoy!` +
+    )}! \nYou have been paired for a chat!` +
     '\n\n' +
     zoomMessage;
 


### PR DESCRIPTION
This makes it so matches are sent at 10pm the previous day, rather than 8am in the morning, which we'd like to change to better accommodate folks in timezones on the other side of the Atlantic, for whom the timing is too late. I *think* these should be the only changes necessary, but I'm not very confident. @thechutrain, would you be willing to take a quick look at this when you get the chance and let me know if there's anything I missed? Also, is there and easy way I can test this without actually sending Zulip messages, to make sure I at least didn't introduce any obvious bugs?